### PR TITLE
Add OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,293 @@
+openapi: 3.1.0
+info:
+  title: SaaS API
+  version: "1.0.0"
+servers:
+  - url: /api/v1
+security:
+  - bearer_auth: []
+paths:
+  /auth/register:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+              required: [email, password]
+      responses:
+        '201':
+          description: Registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        default:
+          $ref: '#/components/responses/problem_response'
+  /auth/oauth:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider_token:
+                  type: string
+              required: [provider_token]
+      responses:
+        '200':
+          description: JWT token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        default:
+          $ref: '#/components/responses/problem_response'
+  /trades:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/trade'
+      responses:
+        '201':
+          description: Created trade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/trade'
+        default:
+          $ref: '#/components/responses/problem_response'
+  /trades/{trade_id}:
+    get:
+      parameters:
+        - in: path
+          name: trade_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Trade data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  trade:
+                    $ref: '#/components/schemas/trade'
+                  pattern_result:
+                    $ref: '#/components/schemas/pattern_result'
+        default:
+          $ref: '#/components/responses/problem_response'
+  /images:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                trade_id:
+                  type: integer
+              required: [trade_id]
+      responses:
+        '200':
+          description: Pre-signed URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  s3_url:
+                    type: string
+        default:
+          $ref: '#/components/responses/problem_response'
+  /patterns/{trade_id}:
+    get:
+      parameters:
+        - in: path
+          name: trade_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pattern result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pattern_result'
+        default:
+          $ref: '#/components/responses/problem_response'
+  /alerts:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/alert'
+      responses:
+        '201':
+          description: Created alert
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/alert'
+        default:
+          $ref: '#/components/responses/problem_response'
+  /alerts/{trade_id}:
+    get:
+      parameters:
+        - in: path
+          name: trade_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Alert list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/alert'
+        default:
+          $ref: '#/components/responses/problem_response'
+components:
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    problem_response:
+      description: Error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/problem'
+  schemas:
+    user:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+        plan:
+          type: string
+      required: [userId, email]
+    trade:
+      type: object
+      properties:
+        tradeId:
+          type: integer
+        userId:
+          type: string
+          format: uuid
+        ticker:
+          type: string
+        side:
+          type: string
+          enum: [LONG, SHORT]
+        priceIn:
+          type: number
+        priceOut:
+          type: number
+          nullable: true
+        size:
+          type: number
+        enteredAt:
+          type: string
+          format: date-time
+        exitedAt:
+          type: string
+          format: date-time
+          nullable: true
+      required: [tradeId, userId, ticker, side, priceIn, size, enteredAt]
+    image:
+      type: object
+      properties:
+        imageId:
+          type: integer
+        tradeId:
+          type: integer
+        s3Url:
+          type: string
+        thumbnailUrl:
+          type: string
+        uploadedAt:
+          type: string
+          format: date-time
+      required: [imageId, tradeId, s3Url, uploadedAt]
+    pattern_result:
+      type: object
+      properties:
+        patternId:
+          type: integer
+        tradeId:
+          type: integer
+        rule:
+          type: string
+        score:
+          type: number
+          format: float
+        advice:
+          type: string
+        diagnosedAt:
+          type: string
+          format: date-time
+      required: [patternId, tradeId, rule, score, diagnosedAt]
+    alert:
+      type: object
+      properties:
+        alertId:
+          type: integer
+        tradeId:
+          type: integer
+        type:
+          type: string
+          enum: [TP, SL]
+        targetPrice:
+          type: number
+        triggeredAt:
+          type: string
+          format: date-time
+          nullable: true
+      required: [alertId, tradeId, type, targetPrice]
+    problem:
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+      required: [type, title, status]


### PR DESCRIPTION
## Summary
- add OpenAPI 3.1 specification for SaaS API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f72e06b24832eace04284d9b14cdb